### PR TITLE
[TLS] closes #1114 - add tlsSni option

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,75 +12,80 @@
 <a name="Redis"></a>
 
 ## Redis ⇐ <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>
-**Kind**: global class  
-**Extends**: <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>, [<code>Commander</code>](#Commander)  
 
-* [Redis](#Redis) ⇐ <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>
-    * [new Redis([port], [host], [options])](#new_Redis_new)
-    * _instance_
-        * [.connect([callback])](#Redis+connect) ⇒ <code>Promise.&lt;void&gt;</code>
-        * [.disconnect()](#Redis+disconnect)
-        * ~~[.end()](#Redis+end)~~
-        * [.duplicate()](#Redis+duplicate)
-        * [.monitor([callback])](#Redis+monitor)
-        * [.getBuiltinCommands()](#Commander+getBuiltinCommands) ⇒ <code>Array.&lt;string&gt;</code>
-        * [.createBuiltinCommand(commandName)](#Commander+createBuiltinCommand) ⇒ <code>object</code>
-        * [.defineCommand(name, definition)](#Commander+defineCommand)
-    * _static_
-        * ~~[.createClient()](#Redis.createClient)~~
+**Kind**: global class  
+**Extends**: <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>, [<code>Commander</code>](#Commander)
+
+- [Redis](#Redis) ⇐ <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>
+  - [new Redis([port], [host], [options])](#new_Redis_new)
+  - _instance_
+    - [.connect([callback])](#Redis+connect) ⇒ <code>Promise.&lt;void&gt;</code>
+    - [.disconnect()](#Redis+disconnect)
+    - ~~[.end()](#Redis+end)~~
+    - [.duplicate()](#Redis+duplicate)
+    - [.monitor([callback])](#Redis+monitor)
+    - [.getBuiltinCommands()](#Commander+getBuiltinCommands) ⇒ <code>Array.&lt;string&gt;</code>
+    - [.createBuiltinCommand(commandName)](#Commander+createBuiltinCommand) ⇒ <code>object</code>
+    - [.defineCommand(name, definition)](#Commander+defineCommand)
+  - _static_
+    - ~~[.createClient()](#Redis.createClient)~~
 
 <a name="new_Redis_new"></a>
 
 ### new Redis([port], [host], [options])
+
 Creates a Redis instance
 
+| Param                                   | Type                                                              | Default                               | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------------- | ----------------------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [port]                                  | <code>number</code> \| <code>string</code> \| <code>Object</code> | <code>6379</code>                     | Port of the Redis server, or a URL string(see the examples below), or the `options` object(see the third argument).                                                                                                                                                                                                                                                                                                                           |
+| [host]                                  | <code>string</code> \| <code>Object</code>                        | <code>&quot;localhost&quot;</code>    | Host of the Redis server, when the first argument is a URL string, this argument is an object represents the options.                                                                                                                                                                                                                                                                                                                         |
+| [options]                               | <code>Object</code>                                               |                                       | Other options.                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| [options.port]                          | <code>number</code>                                               | <code>6379</code>                     | Port of the Redis server.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| [options.host]                          | <code>string</code>                                               | <code>&quot;localhost&quot;</code>    | Host of the Redis server.                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| [options.family]                        | <code>string</code>                                               | <code>4</code>                        | Version of IP stack. Defaults to 4.                                                                                                                                                                                                                                                                                                                                                                                                           |
+| [options.path]                          | <code>string</code>                                               | <code>null</code>                     | Local domain socket path. If set the `port`, `host` and `family` will be ignored.                                                                                                                                                                                                                                                                                                                                                             |
+| [options.keepAlive]                     | <code>number</code>                                               | <code>0</code>                        | TCP KeepAlive on the socket with a X ms delay before start. Set to a non-number value to disable keepAlive.                                                                                                                                                                                                                                                                                                                                   |
+| [options.noDelay]                       | <code>boolean</code>                                              | <code>true</code>                     | Whether to disable the Nagle's Algorithm. By default we disable it to reduce the latency.                                                                                                                                                                                                                                                                                                                                                     |
+| [options.connectionName]                | <code>string</code>                                               | <code>null</code>                     | Connection name.                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [options.db]                            | <code>number</code>                                               | <code>0</code>                        | Database index to use.                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| [options.password]                      | <code>string</code>                                               | <code>null</code>                     | If set, client will send AUTH command with the value of this option when connected.                                                                                                                                                                                                                                                                                                                                                           |
+| [options.dropBufferSupport]             | <code>boolean</code>                                              | <code>false</code>                    | Drop the buffer support for better performance. This option is recommended to be enabled when handling large array response and you don't need the buffer support.                                                                                                                                                                                                                                                                            |
+| [options.enableReadyCheck]              | <code>boolean</code>                                              | <code>true</code>                     | When a connection is established to the Redis server, the server might still be loading the database from disk. While loading, the server not respond to any commands. To work around this, when this option is `true`, ioredis will check the status of the Redis server, and when the Redis server is able to process commands, a `ready` event will be emitted.                                                                            |
+| [options.enableOfflineQueue]            | <code>boolean</code>                                              | <code>true</code>                     | By default, if there is no active connection to the Redis server, commands are added to a queue and are executed once the connection is "ready" (when `enableReadyCheck` is `true`, "ready" means the Redis server has loaded the database from disk, otherwise means the connection to the Redis server has been established). If this option is false, when execute the command when the connection isn't ready, an error will be returned. |
+| [options.connectTimeout]                | <code>number</code>                                               | <code>10000</code>                    | The milliseconds before a timeout occurs during the initial connection to the Redis server.                                                                                                                                                                                                                                                                                                                                                   |
+| [options.autoResubscribe]               | <code>boolean</code>                                              | <code>true</code>                     | After reconnected, if the previous connection was in the subscriber mode, client will auto re-subscribe these channels.                                                                                                                                                                                                                                                                                                                       |
+| [options.autoResendUnfulfilledCommands] | <code>boolean</code>                                              | <code>true</code>                     | If true, client will resend unfulfilled commands(e.g. block commands) in the previous connection when reconnected.                                                                                                                                                                                                                                                                                                                            |
+| [options.lazyConnect]                   | <code>boolean</code>                                              | <code>false</code>                    | By default, When a new `Redis` instance is created, it will connect to Redis server automatically. If you want to keep the instance disconnected until a command is called, you can pass the `lazyConnect` option to the constructor: `javascript var redis = new Redis({ lazyConnect: true }); // No attempting to connect to the Redis server here. // Now let's connect to the Redis server redis.get('foo', function () { });`            |
+| [options.tls]                           | <code>Object</code>                                               |                                       | TLS connection support. See https://github.com/luin/ioredis#tls-options                                                                                                                                                                                                                                                                                                                                                                       |
+| [options.tlsSni]                        | <code>boolean</code>                                              |                                       | If set to true server name indication will be enabled. The name is guessed based on the hostname used when opening the stream.                                                                                                                                                                                                                                                                                                                |
+| [options.keyPrefix]                     | <code>string</code>                                               | <code>&quot;&#x27;&#x27;&quot;</code> | The prefix to prepend to all keys in a command.                                                                                                                                                                                                                                                                                                                                                                                               |
+| [options.retryStrategy]                 | <code>function</code>                                             |                                       | See "Quick Start" section                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| [options.maxRetriesPerRequest]          | <code>number</code>                                               |                                       | See "Quick Start" section                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| [options.reconnectOnError]              | <code>function</code>                                             |                                       | See "Quick Start" section                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| [options.readOnly]                      | <code>boolean</code>                                              | <code>false</code>                    | Enable READONLY mode for the connection. Only available for cluster mode.                                                                                                                                                                                                                                                                                                                                                                     |
+| [options.stringNumbers]                 | <code>boolean</code>                                              | <code>false</code>                    | Force numbers to be always returned as JavaScript strings. This option is necessary when dealing with big numbers (exceed the [-2^53, +2^53] range).                                                                                                                                                                                                                                                                                          |
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| [port] | <code>number</code> \| <code>string</code> \| <code>Object</code> | <code>6379</code> | Port of the Redis server, or a URL string(see the examples below), or the `options` object(see the third argument). |
-| [host] | <code>string</code> \| <code>Object</code> | <code>&quot;localhost&quot;</code> | Host of the Redis server, when the first argument is a URL string, this argument is an object represents the options. |
-| [options] | <code>Object</code> |  | Other options. |
-| [options.port] | <code>number</code> | <code>6379</code> | Port of the Redis server. |
-| [options.host] | <code>string</code> | <code>&quot;localhost&quot;</code> | Host of the Redis server. |
-| [options.family] | <code>string</code> | <code>4</code> | Version of IP stack. Defaults to 4. |
-| [options.path] | <code>string</code> | <code>null</code> | Local domain socket path. If set the `port`, `host` and `family` will be ignored. |
-| [options.keepAlive] | <code>number</code> | <code>0</code> | TCP KeepAlive on the socket with a X ms delay before start. Set to a non-number value to disable keepAlive. |
-| [options.noDelay] | <code>boolean</code> | <code>true</code> | Whether to disable the Nagle's Algorithm. By default we disable it to reduce the latency. |
-| [options.connectionName] | <code>string</code> | <code>null</code> | Connection name. |
-| [options.db] | <code>number</code> | <code>0</code> | Database index to use. |
-| [options.password] | <code>string</code> | <code>null</code> | If set, client will send AUTH command with the value of this option when connected. |
-| [options.dropBufferSupport] | <code>boolean</code> | <code>false</code> | Drop the buffer support for better performance. This option is recommended to be enabled when handling large array response and you don't need the buffer support. |
-| [options.enableReadyCheck] | <code>boolean</code> | <code>true</code> | When a connection is established to the Redis server, the server might still be loading the database from disk. While loading, the server not respond to any commands. To work around this, when this option is `true`, ioredis will check the status of the Redis server, and when the Redis server is able to process commands, a `ready` event will be emitted. |
-| [options.enableOfflineQueue] | <code>boolean</code> | <code>true</code> | By default, if there is no active connection to the Redis server, commands are added to a queue and are executed once the connection is "ready" (when `enableReadyCheck` is `true`, "ready" means the Redis server has loaded the database from disk, otherwise means the connection to the Redis server has been established). If this option is false, when execute the command when the connection isn't ready, an error will be returned. |
-| [options.connectTimeout] | <code>number</code> | <code>10000</code> | The milliseconds before a timeout occurs during the initial connection to the Redis server. |
-| [options.autoResubscribe] | <code>boolean</code> | <code>true</code> | After reconnected, if the previous connection was in the subscriber mode, client will auto re-subscribe these channels. |
-| [options.autoResendUnfulfilledCommands] | <code>boolean</code> | <code>true</code> | If true, client will resend unfulfilled commands(e.g. block commands) in the previous connection when reconnected. |
-| [options.lazyConnect] | <code>boolean</code> | <code>false</code> | By default, When a new `Redis` instance is created, it will connect to Redis server automatically. If you want to keep the instance disconnected until a command is called, you can pass the `lazyConnect` option to the constructor: ```javascript var redis = new Redis({ lazyConnect: true }); // No attempting to connect to the Redis server here. // Now let's connect to the Redis server redis.get('foo', function () { }); ``` |
-| [options.tls] | <code>Object</code> |  | TLS connection support. See https://github.com/luin/ioredis#tls-options |
-| [options.keyPrefix] | <code>string</code> | <code>&quot;&#x27;&#x27;&quot;</code> | The prefix to prepend to all keys in a command. |
-| [options.retryStrategy] | <code>function</code> |  | See "Quick Start" section |
-| [options.maxRetriesPerRequest] | <code>number</code> |  | See "Quick Start" section |
-| [options.reconnectOnError] | <code>function</code> |  | See "Quick Start" section |
-| [options.readOnly] | <code>boolean</code> | <code>false</code> | Enable READONLY mode for the connection. Only available for cluster mode. |
-| [options.stringNumbers] | <code>boolean</code> | <code>false</code> | Force numbers to be always returned as JavaScript strings. This option is necessary when dealing with big numbers (exceed the [-2^53, +2^53] range). |
+**Example**
 
-**Example**  
 ```js
-var Redis = require('ioredis');
+var Redis = require("ioredis");
 
 var redis = new Redis();
 
 var redisOnPort6380 = new Redis(6380);
-var anotherRedis = new Redis(6380, '192.168.100.1');
-var unixSocketRedis = new Redis({ path: '/tmp/echo.sock' });
-var unixSocketRedis2 = new Redis('/tmp/echo.sock');
-var urlRedis = new Redis('redis://user:password@redis-service.com:6379/');
-var urlRedis2 = new Redis('//localhost:6379');
-var authedRedis = new Redis(6380, '192.168.100.1', { password: 'password' });
+var anotherRedis = new Redis(6380, "192.168.100.1");
+var unixSocketRedis = new Redis({ path: "/tmp/echo.sock" });
+var unixSocketRedis2 = new Redis("/tmp/echo.sock");
+var urlRedis = new Redis("redis://user:password@redis-service.com:6379/");
+var urlRedis2 = new Redis("//localhost:6379");
+var authedRedis = new Redis(6380, "192.168.100.1", { password: "password" });
 ```
+
 <a name="Redis+connect"></a>
 
 ### redis.connect([callback]) ⇒ <code>Promise.&lt;void&gt;</code>
+
 Create a connection to Redis.
 This method will be invoked automatically when creating a new Redis instance
 unless `lazyConnect: true` is passed.
@@ -89,15 +94,16 @@ When calling this method manually, a Promise is returned, which will
 be resolved when the connection status is ready.
 
 **Kind**: instance method of [<code>Redis</code>](#Redis)  
-**Access**: public  
+**Access**: public
 
-| Param | Type |
-| --- | --- |
-| [callback] | <code>function</code> | 
+| Param      | Type                  |
+| ---------- | --------------------- |
+| [callback] | <code>function</code> |
 
 <a name="Redis+disconnect"></a>
 
 ### redis.disconnect()
+
 Disconnect from Redis.
 
 This method closes the connection immediately,
@@ -109,7 +115,8 @@ If you want to wait for the pending replies, use Redis#quit instead.
 <a name="Redis+end"></a>
 
 ### ~~redis.end()~~
-***Deprecated***
+
+**_Deprecated_**
 
 Disconnect from Redis.
 
@@ -117,18 +124,22 @@ Disconnect from Redis.
 <a name="Redis+duplicate"></a>
 
 ### redis.duplicate()
+
 Create a new instance with the same options as the current one.
 
 **Kind**: instance method of [<code>Redis</code>](#Redis)  
 **Access**: public  
-**Example**  
+**Example**
+
 ```js
 var redis = new Redis(6380);
 var anotherRedis = redis.duplicate();
 ```
+
 <a name="Redis+monitor"></a>
 
 ### redis.monitor([callback])
+
 Listen for all requests received by the server in real time.
 
 This command will create a new connection to Redis and send a
@@ -136,32 +147,35 @@ MONITOR command via the new connection in order to avoid disturbing
 the current connection.
 
 **Kind**: instance method of [<code>Redis</code>](#Redis)  
-**Access**: public  
+**Access**: public
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param      | Type                  | Description                                                 |
+| ---------- | --------------------- | ----------------------------------------------------------- |
 | [callback] | <code>function</code> | The callback function. If omit, a promise will be returned. |
 
-**Example**  
+**Example**
+
 ```js
 var redis = new Redis();
 redis.monitor(function (err, monitor) {
   // Entering monitoring mode.
-  monitor.on('monitor', function (time, args, source, database) {
+  monitor.on("monitor", function (time, args, source, database) {
     console.log(time + ": " + util.inspect(args));
   });
 });
 
 // supports promise as well as other commands
 redis.monitor().then(function (monitor) {
-  monitor.on('monitor', function (time, args, source, database) {
+  monitor.on("monitor", function (time, args, source, database) {
     console.log(time + ": " + util.inspect(args));
   });
 });
 ```
+
 <a name="Commander+getBuiltinCommands"></a>
 
 ### redis.getBuiltinCommands() ⇒ <code>Array.&lt;string&gt;</code>
+
 Return supported builtin commands
 
 **Kind**: instance method of [<code>Redis</code>](#Redis)  
@@ -170,34 +184,37 @@ Return supported builtin commands
 <a name="Commander+createBuiltinCommand"></a>
 
 ### redis.createBuiltinCommand(commandName) ⇒ <code>object</code>
+
 Create a builtin command
 
 **Kind**: instance method of [<code>Redis</code>](#Redis)  
 **Returns**: <code>object</code> - functions  
-**Access**: public  
+**Access**: public
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param       | Type                | Description  |
+| ----------- | ------------------- | ------------ |
 | commandName | <code>string</code> | command name |
 
 <a name="Commander+defineCommand"></a>
 
 ### redis.defineCommand(name, definition)
+
 Define a custom command using lua script
 
-**Kind**: instance method of [<code>Redis</code>](#Redis)  
+**Kind**: instance method of [<code>Redis</code>](#Redis)
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| name | <code>string</code> |  | the command name |
-| definition | <code>object</code> |  |  |
-| definition.lua | <code>string</code> |  | the lua code |
+| Param                     | Type                | Default       | Description                                                                                                              |
+| ------------------------- | ------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| name                      | <code>string</code> |               | the command name                                                                                                         |
+| definition                | <code>object</code> |               |                                                                                                                          |
+| definition.lua            | <code>string</code> |               | the lua code                                                                                                             |
 | [definition.numberOfKeys] | <code>number</code> | <code></code> | the number of keys. If omit, you have to pass the number of keys as the first argument every time you invoke the command |
 
 <a name="Redis.createClient"></a>
 
 ### ~~Redis.createClient()~~
-***Deprecated***
+
+**_Deprecated_**
 
 Create a Redis instance
 
@@ -205,46 +222,48 @@ Create a Redis instance
 <a name="Cluster"></a>
 
 ## Cluster ⇐ <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>
-**Kind**: global class  
-**Extends**: <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>, [<code>Commander</code>](#Commander)  
 
-* [Cluster](#Cluster) ⇐ <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>
-    * [new Cluster(startupNodes, options)](#new_Cluster_new)
-    * [.connect()](#Cluster+connect) ⇒ <code>Promise</code>
-    * [.disconnect([reconnect])](#Cluster+disconnect)
-    * [.quit([callback])](#Cluster+quit) ⇒ <code>Promise</code>
-    * [.nodes([role])](#Cluster+nodes) ⇒ [<code>Array.&lt;Redis&gt;</code>](#Redis)
-    * [.getBuiltinCommands()](#Commander+getBuiltinCommands) ⇒ <code>Array.&lt;string&gt;</code>
-    * [.createBuiltinCommand(commandName)](#Commander+createBuiltinCommand) ⇒ <code>object</code>
-    * [.defineCommand(name, definition)](#Commander+defineCommand)
-    * *[.sendCommand()](#Commander+sendCommand)*
+**Kind**: global class  
+**Extends**: <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>, [<code>Commander</code>](#Commander)
+
+- [Cluster](#Cluster) ⇐ <code>[EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter)</code>
+  - [new Cluster(startupNodes, options)](#new_Cluster_new)
+  - [.connect()](#Cluster+connect) ⇒ <code>Promise</code>
+  - [.disconnect([reconnect])](#Cluster+disconnect)
+  - [.quit([callback])](#Cluster+quit) ⇒ <code>Promise</code>
+  - [.nodes([role])](#Cluster+nodes) ⇒ [<code>Array.&lt;Redis&gt;</code>](#Redis)
+  - [.getBuiltinCommands()](#Commander+getBuiltinCommands) ⇒ <code>Array.&lt;string&gt;</code>
+  - [.createBuiltinCommand(commandName)](#Commander+createBuiltinCommand) ⇒ <code>object</code>
+  - [.defineCommand(name, definition)](#Commander+defineCommand)
+  - _[.sendCommand()](#Commander+sendCommand)_
 
 <a name="new_Cluster_new"></a>
 
 ### new Cluster(startupNodes, options)
+
 Creates a Redis Cluster instance
 
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| startupNodes | <code>Array.&lt;Object&gt;</code> |  | An array of nodes in the cluster, [{ port: number, host: string }] |
-| options | <code>Object</code> |  |  |
-| [options.clusterRetryStrategy] | <code>function</code> |  | See "Quick Start" section |
-| [options.dnsLookup] | <code>function(hostname, function(err, addr, family))<code> | <code>[dns.lookup](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback)</code> | Function used to resolve DNS hostnames of Redis cluster members. |
-| [options.enableOfflineQueue] | <code>boolean</code> | <code>true</code> | See Redis class |
-| [options.enableReadyCheck] | <code>boolean</code> | <code>true</code> | When enabled, ioredis only emits "ready" event when `CLUSTER INFO` command reporting the cluster is ready for handling commands. |
-| [options.scaleReads] | <code>string</code> | <code>&quot;master&quot;</code> | Scale reads to the node with the specified role. Available values are "master", "slave" and "all". |
-| [options.maxRedirections] | <code>number</code> | <code>16</code> | When a MOVED or ASK error is received, client will redirect the command to another node. This option limits the max redirections allowed to send a command. |
-| [options.retryDelayOnFailover] | <code>number</code> | <code>100</code> | When an error is received when sending a command(e.g. "Connection is closed." when the target Redis node is down), |
-| [options.retryDelayOnClusterDown] | <code>number</code> | <code>100</code> | When a CLUSTERDOWN error is received, client will retry if `retryDelayOnClusterDown` is valid delay time. |
-| [options.retryDelayOnTryAgain] | <code>number</code> | <code>100</code> | When a TRYAGAIN error is received, client will retry if `retryDelayOnTryAgain` is valid delay time. |
-| [options.slotsRefreshTimeout] | <code>number</code> | <code>1000</code> | The milliseconds before a timeout occurs while refreshing slots from the cluster. |
-| [options.slotsRefreshInterval] | <code>number</code> | <code>5000</code> | The milliseconds between every automatic slots refresh. |
-| [options.redisOptions] | <code>Object</code> |  | Passed to the constructor of `Redis`. |
+| Param                             | Type                                                        | Default                                                                                             | Description                                                                                                                                                 |
+| --------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| startupNodes                      | <code>Array.&lt;Object&gt;</code>                           |                                                                                                     | An array of nodes in the cluster, [{ port: number, host: string }]                                                                                          |
+| options                           | <code>Object</code>                                         |                                                                                                     |                                                                                                                                                             |
+| [options.clusterRetryStrategy]    | <code>function</code>                                       |                                                                                                     | See "Quick Start" section                                                                                                                                   |
+| [options.dnsLookup]               | <code>function(hostname, function(err, addr, family))<code> | <code>[dns.lookup](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback)</code> | Function used to resolve DNS hostnames of Redis cluster members.                                                                                            |
+| [options.enableOfflineQueue]      | <code>boolean</code>                                        | <code>true</code>                                                                                   | See Redis class                                                                                                                                             |
+| [options.enableReadyCheck]        | <code>boolean</code>                                        | <code>true</code>                                                                                   | When enabled, ioredis only emits "ready" event when `CLUSTER INFO` command reporting the cluster is ready for handling commands.                            |
+| [options.scaleReads]              | <code>string</code>                                         | <code>&quot;master&quot;</code>                                                                     | Scale reads to the node with the specified role. Available values are "master", "slave" and "all".                                                          |
+| [options.maxRedirections]         | <code>number</code>                                         | <code>16</code>                                                                                     | When a MOVED or ASK error is received, client will redirect the command to another node. This option limits the max redirections allowed to send a command. |
+| [options.retryDelayOnFailover]    | <code>number</code>                                         | <code>100</code>                                                                                    | When an error is received when sending a command(e.g. "Connection is closed." when the target Redis node is down),                                          |
+| [options.retryDelayOnClusterDown] | <code>number</code>                                         | <code>100</code>                                                                                    | When a CLUSTERDOWN error is received, client will retry if `retryDelayOnClusterDown` is valid delay time.                                                   |
+| [options.retryDelayOnTryAgain]    | <code>number</code>                                         | <code>100</code>                                                                                    | When a TRYAGAIN error is received, client will retry if `retryDelayOnTryAgain` is valid delay time.                                                         |
+| [options.slotsRefreshTimeout]     | <code>number</code>                                         | <code>1000</code>                                                                                   | The milliseconds before a timeout occurs while refreshing slots from the cluster.                                                                           |
+| [options.slotsRefreshInterval]    | <code>number</code>                                         | <code>5000</code>                                                                                   | The milliseconds between every automatic slots refresh.                                                                                                     |
+| [options.redisOptions]            | <code>Object</code>                                         |                                                                                                     | Passed to the constructor of `Redis`.                                                                                                                       |
 
 <a name="Cluster+connect"></a>
 
 ### cluster.connect() ⇒ <code>Promise</code>
+
 Connect to a cluster
 
 **Kind**: instance method of [<code>Cluster</code>](#Cluster)  
@@ -252,44 +271,48 @@ Connect to a cluster
 <a name="Cluster+disconnect"></a>
 
 ### cluster.disconnect([reconnect])
+
 Disconnect from every node in the cluster.
 
 **Kind**: instance method of [<code>Cluster</code>](#Cluster)  
-**Access**: public  
+**Access**: public
 
-| Param | Type |
-| --- | --- |
-| [reconnect] | <code>boolean</code> | 
+| Param       | Type                 |
+| ----------- | -------------------- |
+| [reconnect] | <code>boolean</code> |
 
 <a name="Cluster+quit"></a>
 
 ### cluster.quit([callback]) ⇒ <code>Promise</code>
+
 Quit the cluster gracefully.
 
 **Kind**: instance method of [<code>Cluster</code>](#Cluster)  
 **Returns**: <code>Promise</code> - return 'OK' if successfully  
-**Access**: public  
+**Access**: public
 
-| Param | Type |
-| --- | --- |
-| [callback] | <code>function</code> | 
+| Param      | Type                  |
+| ---------- | --------------------- |
+| [callback] | <code>function</code> |
 
 <a name="Cluster+nodes"></a>
 
 ### cluster.nodes([role]) ⇒ [<code>Array.&lt;Redis&gt;</code>](#Redis)
+
 Get nodes with the specified role
 
 **Kind**: instance method of [<code>Cluster</code>](#Cluster)  
 **Returns**: [<code>Array.&lt;Redis&gt;</code>](#Redis) - array of nodes  
-**Access**: public  
+**Access**: public
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
+| Param  | Type                | Default                      | Description                      |
+| ------ | ------------------- | ---------------------------- | -------------------------------- |
 | [role] | <code>string</code> | <code>&quot;all&quot;</code> | role, "master", "slave" or "all" |
 
 <a name="Commander+getBuiltinCommands"></a>
 
 ### cluster.getBuiltinCommands() ⇒ <code>Array.&lt;string&gt;</code>
+
 Return supported builtin commands
 
 **Kind**: instance method of [<code>Cluster</code>](#Cluster)  
@@ -298,33 +321,36 @@ Return supported builtin commands
 <a name="Commander+createBuiltinCommand"></a>
 
 ### cluster.createBuiltinCommand(commandName) ⇒ <code>object</code>
+
 Create a builtin command
 
 **Kind**: instance method of [<code>Cluster</code>](#Cluster)  
 **Returns**: <code>object</code> - functions  
-**Access**: public  
+**Access**: public
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param       | Type                | Description  |
+| ----------- | ------------------- | ------------ |
 | commandName | <code>string</code> | command name |
 
 <a name="Commander+defineCommand"></a>
 
 ### cluster.defineCommand(name, definition)
+
 Define a custom command using lua script
 
-**Kind**: instance method of [<code>Cluster</code>](#Cluster)  
+**Kind**: instance method of [<code>Cluster</code>](#Cluster)
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| name | <code>string</code> |  | the command name |
-| definition | <code>object</code> |  |  |
-| definition.lua | <code>string</code> |  | the lua code |
+| Param                     | Type                | Default       | Description                                                                                                              |
+| ------------------------- | ------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| name                      | <code>string</code> |               | the command name                                                                                                         |
+| definition                | <code>object</code> |               |                                                                                                                          |
+| definition.lua            | <code>string</code> |               | the lua code                                                                                                             |
 | [definition.numberOfKeys] | <code>number</code> | <code></code> | the number of keys. If omit, you have to pass the number of keys as the first argument every time you invoke the command |
 
 <a name="Commander+sendCommand"></a>
 
-### *cluster.sendCommand()*
+### _cluster.sendCommand()_
+
 Send a command
 
 **Kind**: instance abstract method of [<code>Cluster</code>](#Cluster)  
@@ -333,30 +359,32 @@ Send a command
 <a name="Commander"></a>
 
 ## Commander
-**Kind**: global class  
 
-* [Commander](#Commander)
-    * [new Commander()](#new_Commander_new)
-    * [.getBuiltinCommands()](#Commander+getBuiltinCommands) ⇒ <code>Array.&lt;string&gt;</code>
-    * [.createBuiltinCommand(commandName)](#Commander+createBuiltinCommand) ⇒ <code>object</code>
-    * [.defineCommand(name, definition)](#Commander+defineCommand)
-    * *[.sendCommand()](#Commander+sendCommand)*
+**Kind**: global class
+
+- [Commander](#Commander)
+  - [new Commander()](#new_Commander_new)
+  - [.getBuiltinCommands()](#Commander+getBuiltinCommands) ⇒ <code>Array.&lt;string&gt;</code>
+  - [.createBuiltinCommand(commandName)](#Commander+createBuiltinCommand) ⇒ <code>object</code>
+  - [.defineCommand(name, definition)](#Commander+defineCommand)
+  - _[.sendCommand()](#Commander+sendCommand)_
 
 <a name="new_Commander_new"></a>
 
 ### new Commander()
+
 Commander
 
 This is the base class of Redis, Redis.Cluster and Pipeline
 
-
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
+| Param                            | Type                 | Default            | Description                                                                          |
+| -------------------------------- | -------------------- | ------------------ | ------------------------------------------------------------------------------------ |
 | [options.showFriendlyErrorStack] | <code>boolean</code> | <code>false</code> | Whether to show a friendly error stack. Will decrease the performance significantly. |
 
 <a name="Commander+getBuiltinCommands"></a>
 
 ### commander.getBuiltinCommands() ⇒ <code>Array.&lt;string&gt;</code>
+
 Return supported builtin commands
 
 **Kind**: instance method of [<code>Commander</code>](#Commander)  
@@ -365,34 +393,37 @@ Return supported builtin commands
 <a name="Commander+createBuiltinCommand"></a>
 
 ### commander.createBuiltinCommand(commandName) ⇒ <code>object</code>
+
 Create a builtin command
 
 **Kind**: instance method of [<code>Commander</code>](#Commander)  
 **Returns**: <code>object</code> - functions  
-**Access**: public  
+**Access**: public
 
-| Param | Type | Description |
-| --- | --- | --- |
+| Param       | Type                | Description  |
+| ----------- | ------------------- | ------------ |
 | commandName | <code>string</code> | command name |
 
 <a name="Commander+defineCommand"></a>
 
 ### commander.defineCommand(name, definition)
+
 Define a custom command using lua script
 
-**Kind**: instance method of [<code>Commander</code>](#Commander)  
+**Kind**: instance method of [<code>Commander</code>](#Commander)
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| name | <code>string</code> |  | the command name |
-| definition | <code>object</code> |  |  |
-| definition.lua | <code>string</code> |  | the lua code |
+| Param                     | Type                | Default       | Description                                                                                                              |
+| ------------------------- | ------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| name                      | <code>string</code> |               | the command name                                                                                                         |
+| definition                | <code>object</code> |               |                                                                                                                          |
+| definition.lua            | <code>string</code> |               | the lua code                                                                                                             |
 | [definition.numberOfKeys] | <code>number</code> | <code></code> | the number of keys. If omit, you have to pass the number of keys as the first argument every time you invoke the command |
 
 <a name="Commander+sendCommand"></a>
 
-### *commander.sendCommand()*
+### _commander.sendCommand()_
+
 Send a command
 
 **Kind**: instance abstract method of [<code>Commander</code>](#Commander)  
-**Access**: public  
+**Access**: public

--- a/README.md
+++ b/README.md
@@ -732,6 +732,21 @@ Alternatively, specify the connection through a [`rediss://` URL](https://www.ia
 var redis = new Redis("rediss://redis.my-service.com");
 ```
 
+To enable the Server Name Indication TLS extension (SNI) set the `tlsSni` option to `true`.
+The name is guessed based on the hostname used when opening the stream.
+
+```javascript
+var redis = new Redis({
+  host: "localhost",
+  // optional TLS options (see above)
+  tls: {...},
+  tlsSni: true,
+});
+```
+
+This will basically copy the Redis hostname to `tls.servername` before the connection initialization,
+allowing each node of a Redis Cluster to possess its own SNI.
+
 <hr>
 
 ## Sentinel

--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -74,12 +74,14 @@ export default class ClusterSubscriber {
     this.subscriber = new Redis({
       port: options.port,
       host: options.host,
+      hostOriginal: options.hostOriginal,
       username: options.username,
       password: options.password,
       enableReadyCheck: true,
       connectionName: SUBSCRIBER_CONNECTION_NAME,
       lazyConnect: true,
       tls: options.tls,
+      tlsSni: options.tlsSni,
     });
 
     // Ignore the errors since they're handled in the connection pool.

--- a/lib/cluster/util.ts
+++ b/lib/cluster/util.ts
@@ -55,6 +55,8 @@ export function normalizeNodeOptions(
     }
     if (!options.host) {
       options.host = "127.0.0.1";
+    } else {
+      options.hostOriginal = options.host;
     }
 
     return options;

--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -12,6 +12,7 @@ export function isIIpcConnectionOptions(
 
 export interface ITcpConnectionOptions extends TcpNetConnectOpts {
   tls?: SecureContextOptions;
+  tlsSni?: boolean;
 }
 
 export interface IIpcConnectionOptions extends IpcNetConnectOpts {
@@ -29,6 +30,7 @@ export default class StandaloneConnector extends AbstractConnector {
     const { options } = this;
     this.connecting = true;
 
+    let isTls = false;
     let connectionOptions: any;
     if (isIIpcConnectionOptions(options)) {
       connectionOptions = {
@@ -41,6 +43,10 @@ export default class StandaloneConnector extends AbstractConnector {
       }
       if (options.host != null) {
         connectionOptions.host = options.host;
+        if (options.tlsSni) {
+          isTls = true;
+          connectionOptions.servername = options.host;
+        }
       }
       if (options.family != null) {
         connectionOptions.family = options.family;
@@ -48,6 +54,7 @@ export default class StandaloneConnector extends AbstractConnector {
     }
 
     if (options.tls) {
+      isTls = true;
       Object.assign(connectionOptions, options.tls);
     }
 
@@ -66,7 +73,7 @@ export default class StandaloneConnector extends AbstractConnector {
         }
 
         try {
-          if (options.tls) {
+          if (isTls) {
             this.stream = createTLSConnection(connectionOptions);
           } else {
             this.stream = createConnection(connectionOptions);

--- a/lib/connectors/StandaloneConnector.ts
+++ b/lib/connectors/StandaloneConnector.ts
@@ -13,6 +13,7 @@ export function isIIpcConnectionOptions(
 export interface ITcpConnectionOptions extends TcpNetConnectOpts {
   tls?: SecureContextOptions;
   tlsSni?: boolean;
+  hostOriginal?: string;
 }
 
 export interface IIpcConnectionOptions extends IpcNetConnectOpts {
@@ -43,10 +44,10 @@ export default class StandaloneConnector extends AbstractConnector {
       }
       if (options.host != null) {
         connectionOptions.host = options.host;
-        if (options.tlsSni) {
-          isTls = true;
-          connectionOptions.servername = options.host;
-        }
+      }
+      if (options.tlsSni && (options.hostOriginal || options.host)) {
+        isTls = true;
+        connectionOptions.servername = options.hostOriginal || options.host;
       }
       if (options.family != null) {
         connectionOptions.family = options.family;

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -26,6 +26,7 @@ export interface IRedisOptions
   stringNumbers?: boolean;
   maxRetriesPerRequest?: number;
   maxLoadingRetryTime?: number;
+  tlsSni?: boolean;
 }
 
 export const DEFAULT_REDIS_OPTIONS: IRedisOptions = {

--- a/test/functional/cluster/nat.ts
+++ b/test/functional/cluster/nat.ts
@@ -199,7 +199,12 @@ describe("NAT", () => {
 
     cluster.on("ready", () => {
       expect(reset.secondCall.args[0]).to.deep.equal([
-        { host: "127.0.0.1", port: 30001, readOnly: false },
+        {
+          host: "127.0.0.1",
+          hostOriginal: "127.0.0.1",
+          port: 30001,
+          readOnly: false,
+        },
       ]);
       cluster.disconnect();
       done();

--- a/test/functional/tls.ts
+++ b/test/functional/tls.ts
@@ -30,6 +30,32 @@ describe("tls option", () => {
         redis.on("end", () => done());
       });
     });
+
+    it("supports tls sni", (done) => {
+      let redis;
+
+      // @ts-ignore
+      const stub = sinon.stub(tls, "connect").callsFake((op) => {
+        // @ts-ignore
+        expect(op.host).to.eql("localhost");
+        // @ts-ignore
+        expect(op.servername).to.eql("localhost");
+        // @ts-ignore
+        expect(op.port).to.eql(6379);
+        const stream = net.createConnection(op);
+        stream.on("connect", (data) => {
+          stream.emit("secureConnect", data);
+        });
+        return stream;
+      });
+
+      redis = new Redis({ tlsSni: true });
+      redis.on("ready", () => {
+        redis.disconnect();
+        stub.restore();
+        redis.on("end", () => done());
+      });
+    });
   });
 
   describe("Sentinel", () => {

--- a/test/unit/connectors/connector.ts
+++ b/test/unit/connectors/connector.ts
@@ -39,5 +39,22 @@ describe("StandaloneConnector", () => {
       expect(spy.firstCall.args[0]).to.eql({ port: 6379, ca: "on" });
       connector.disconnect();
     });
+
+    it("supports tls sni", async () => {
+      const spy = sinon.stub(tls, "connect");
+      const connector = new StandaloneConnector({
+        host: "localhost",
+        port: 6379,
+        tlsSni: true,
+      });
+      await connector.connect(() => {});
+      expect(spy.calledOnce).to.eql(true);
+      expect(spy.firstCall.args[0]).to.eql({
+        host: "localhost",
+        port: 6379,
+        servername: "localhost",
+      });
+      connector.disconnect();
+    });
   });
 });


### PR DESCRIPTION
Hi everyone,

This PR introduces a new boolean option `tlsSni` that will basically, when enabled, copy the Redis hostname to `tls.servername` before the connection initialization,
allowing each node of a Redis Cluster to possess its own SNI.

This PR has been opened following the issue #1114 

It is also related to #948

Thank you for your time!

PS: For clusers I had to copy the `options.host` value to `options.hostOriginal` before it gets processed by the `dnsLookup` function, so that the original hostname could get passed to the `tls.servername` option instead of its IP.