### PR TITLE
fix: geo units must be lowercase up to Redis v7

### DIFF
--- a/lib/utils/RedisCommander.ts
+++ b/lib/utils/RedisCommander.ts
@@ -3394,56 +3394,56 @@ interface RedisCommander<Context extends ClientContext = { type: "default" }> {
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    m: "M",
+    m: "m",
     callback?: Callback<string | null>
   ): Result<string | null, Context>;
   geodistBuffer(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    m: "M",
+    m: "m",
     callback?: Callback<Buffer | null>
   ): Result<Buffer | null, Context>;
   geodist(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    km: "KM",
+    km: "km",
     callback?: Callback<string | null>
   ): Result<string | null, Context>;
   geodistBuffer(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    km: "KM",
+    km: "km",
     callback?: Callback<Buffer | null>
   ): Result<Buffer | null, Context>;
   geodist(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    ft: "FT",
+    ft: "ft",
     callback?: Callback<string | null>
   ): Result<string | null, Context>;
   geodistBuffer(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    ft: "FT",
+    ft: "ft",
     callback?: Callback<Buffer | null>
   ): Result<Buffer | null, Context>;
   geodist(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    mi: "MI",
+    mi: "mi",
     callback?: Callback<string | null>
   ): Result<string | null, Context>;
   geodistBuffer(
     key: RedisKey,
     member1: string | Buffer | number,
     member2: string | Buffer | number,
-    mi: "MI",
+    mi: "mi",
     callback?: Callback<Buffer | null>
   ): Result<Buffer | null, Context>;
 


### PR DESCRIPTION
Prior to Redis v7 various geo commands supported a [case sensitive "unit" parameter](https://github.com/redis/redis/blob/6.2.7/src/geo.c#L128-L141.) (in Redis v7 and above it is [case-insensitive](https://github.com/redis/redis/blob/7.0.0/src/geo.c#L128-L141)). In particular, for clients running v6.2.7 and below the units m, km, ft, mi must be lowercase, or else an error is thrown: `ERR unsupported unit provided. please use m, km, ft, mi`. 

While this is true for several geo-like commands it appears that in this library only the `geodist` command explicitly types this parameter. However, the units here are specified to be uppercase which is incompatible with older versions. Since v7+ is case insensitive, this PR proposes to use lowercase for the sake of compatibility.