### PR TITLE
fix: make autopipelining group commands by slot instead of by node

### DIFF
--- a/lib/autoPipelining.ts
+++ b/lib/autoPipelining.ts
@@ -146,9 +146,7 @@ export function executeWithAutoPipelining(
   // ioredis will only flatten one level of the array, in the Command constructor.
   const prefix = client.options.keyPrefix || "";
   const slotKey = client.isCluster
-    ? client.slots[
-        calculateSlot(`${prefix}${getFirstValueInFlattenedArray(args)}`)
-      ].join(",")
+    ? calculateSlot(`${prefix}${getFirstValueInFlattenedArray(args)}`)
     : "main";
 
   if (!client._autoPipelines.has(slotKey)) {


### PR DESCRIPTION
This change solved my problems with auto-pipelining + clusters.
ioredis itself states that pipeline commands should target keys in the same slot:
https://github.com/luin/ioredis/blob/807cfc0e211f72885e00228edc5e72878916a938/lib/Pipeline.ts#L309