### PR TITLE
turn "Stream isn't writable" into its own error class and export it

### DIFF
--- a/lib/Redis.ts
+++ b/lib/Redis.ts
@@ -33,6 +33,7 @@ import applyMixin from "./utils/applyMixin";
 import Commander from "./utils/Commander";
 import { defaults, noop } from "./utils/lodash";
 import Deque = require("denque");
+import { StreamNotWritable } from "./errors";
 const debug = Debug("redis");
 
 type RedisStatus =
@@ -463,9 +464,7 @@ class Redis extends Commander implements DataHandledable {
     if (!writable) {
       if (!this.options.enableOfflineQueue) {
         command.reject(
-          new Error(
-            "Stream isn't writeable and enableOfflineQueue options is false"
-          )
+          new StreamNotWritable()
         );
         return command.promise;
       }

--- a/lib/errors/StreamNotWritable.ts
+++ b/lib/errors/StreamNotWritable.ts
@@ -1,0 +1,7 @@
+export default class StreamNotWritable extends Error {
+    static message = "Stream isn't writeable and enableOfflineQueue options is false";
+
+    constructor() {
+        super(StreamNotWritable.message);
+    }
+}

--- a/lib/errors/index.ts
+++ b/lib/errors/index.ts
@@ -1,3 +1,7 @@
 import MaxRetriesPerRequestError from "./MaxRetriesPerRequestError";
+import StreamNotWritable from "./StreamNotWritable";
 
-export { MaxRetriesPerRequestError };
+export {
+    MaxRetriesPerRequestError,
+    StreamNotWritable
+};

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -70,6 +70,8 @@ export type {
 // No TS typings
 export const ReplyError = require("redis-errors").ReplyError;
 
+export * as Errors from "./errors";
+
 /**
  * @ignore
  */

--- a/test/functional/send_command.ts
+++ b/test/functional/send_command.ts
@@ -1,5 +1,6 @@
 import Redis from "../../lib/Redis";
 import { expect } from "chai";
+import { StreamNotWritable } from "../../lib/errors";
 
 describe("send command", () => {
   it("should support callback", (done) => {
@@ -260,9 +261,7 @@ describe("send command", () => {
     const redis = new Redis({ enableOfflineQueue: false });
     redis.on("connect", () => {
       redis.get("foo", function (err) {
-        expect(err.message).to.eql(
-          "Stream isn't writeable and enableOfflineQueue options is false"
-        );
+        expect(err).to.be(typeof(StreamNotWritable));
         done();
       });
     });


### PR DESCRIPTION
Create a class StreamNotWritable in lib/errors/ and throw it instead of using `new Error`

### reason

makes detection of that case easier on the user-side

### context

We have noticed that in a kubernetes cluster sometime a server connection can become un-writable but still active
That's ok when enableOfflineQueue is true
But when it's not, a new Error is thrown with the message 
```js
"Stream isn't writeable and enableOfflineQueue options is false"
```
if we want to use `reconnectOnError` and detect that specific error
we have to copy paste this string into the user side which isn't very robust / future-safe
With this change detection of this error would become something like so:
```
reconnectOnError(err => {
     if (err instanceof StreamNotWritable) { ... }
});
```