### PR TITLE
fix: TypeError: Cannot redefine property: default

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,3 @@
-exports = module.exports = require("./Redis").default;
-
 export { default } from "./Redis";
 export { default as Redis } from "./Redis";
 export { default as Cluster } from "./cluster";


### PR DESCRIPTION
```sh
/Users/path/to/node_modules/.pnpm/ioredis@5.3.2/node_modules/ioredis/built/index.js:6
Object.defineProperty(exports, "default", { enumerable: true, get: function () { return Redis_1.default; } });
       ^

TypeError: Cannot redefine property: default
```