### PR TITLE
fix: hide sensitive data from debug logs

### DIFF
--- a/lib/utils/debug.ts
+++ b/lib/utils/debug.ts
@@ -62,12 +62,24 @@ export default function genDebugFunction(
       return; // no-op
     }
 
+    let sanitizeString = false;
     // we skip the first arg because that is the message
     for (let i = 1; i < args.length; i++) {
-      const str = getStringValue(args[i]);
-      if (typeof str === "string" && str.length > MAX_ARGUMENT_LENGTH) {
-        args[i] = genRedactedString(str, MAX_ARGUMENT_LENGTH);
-      }
+        const str = getStringValue(args[i]);;
+        if(sanitizeString) {
+            // The previous array index indicates this current index
+            // needs to be removed from the logs.
+            args[i] = '***********';
+            sanitizeString = false;
+            continue;
+        }
+        if(typeof str === "string" && str === 'auth') {
+            // Expect the next array index will contain 
+            // sensitive data that should not be in plaintext
+            sanitizeString = true;
+        } else if (typeof str === "string" && str.length > MAX_ARGUMENT_LENGTH) {
+            args[i] = genRedactedString(str, MAX_ARGUMENT_LENGTH);
+        }
     }
 
     return fn.apply(null, args);


### PR DESCRIPTION
Fixes https://github.com/redis/ioredis/issues/1796

With my limited knowledge of this code base, I have tried to patch the specific scenario reported in https://github.com/redis/ioredis/issues/1796.

I think there can be improvements to this code but I lack the code base knowledge to put this logic in an universal place where all logs will sanitize values associated with the command `auth`.

# How I tested using `ioredis@5.3.2`
1. `docker pull redis/redis-stack-server:latest`
1. `docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest`
1. `npm install ioredis`
1. Edit `node_modules/ioredis/built/utils/debug.js` directly with this PR code
1. Run `DEBUG=ioredis:* node app.js` with the file below.
```
const http = require('http');
const Redis = require('ioredis');

const hostname = '127.0.0.1';
const port = 3000;

const redisClient = new Redis({
    host: 'localhost',
    port: 6379,
    password: 'foobar'
});

redisClient.on('connect', () => {
    console.info('connected to redis server');
});

const server = http.createServer((req, res) => {
  res.statusCode = 200;
  res.setHeader('Content-Type', 'text/plain');
  res.end('Hello World');
});

server.listen(port, hostname, () => {
  console.log(`Server running at http://${hostname}:${port}/`);
});

```

5. Observed the log and see message ` ioredis:redis write command[127.0.0.1:6379]: 0 -> auth('***********') +1ms`