### PR TITLE
docs: update cluster options

### DIFF
--- a/lib/cluster/ClusterOptions.ts
+++ b/lib/cluster/ClusterOptions.ts
@@ -114,8 +114,6 @@ export interface ClusterOptions extends CommanderOptions {
 
   /**
    * The milliseconds between every automatic slots refresh.
-   *
-   * @default 5000
    */
   slotsRefreshInterval?: number;
 


### PR DESCRIPTION
The default value has been removed by https://github.com/redis/ioredis/commit/370fa625cd20bfe62f41c38088e596c7a6f0619c in 2022 (I can't find a PR. Will appreciate if you can link me to a PR with more explanation 🙏).

And the text in `README.md` has been updated with #1687. However, the document in code has been left as-is, which is providing the wrong information by now 🥲 