### PR TITLE
Default retry strategy uses exponential backoff and jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,9 +761,12 @@ using the `retryStrategy` option:
 ```javascript
 const redis = new Redis({
   // This is the default value of `retryStrategy`
-  retryStrategy(times) {
-    const delay = Math.min(times * 50, 2000);
-    return delay;
+  retryStrategy: function (times) {
+    // Generate a random jitter between 0 – 200 ms:
+    const jitter = Math.floor(Math.random() * 200);
+    // Delay is an exponential back off, (times^2) * 50 ms, with a maximum value of 2000 ms:
+    const delay = Math.min(Math.pow(2, times) * 50, 2000);
+    return delay + jitter;
   },
 });
 ```

--- a/lib/redis/RedisOptions.ts
+++ b/lib/redis/RedisOptions.ts
@@ -193,7 +193,11 @@ export const DEFAULT_REDIS_OPTIONS: RedisOptions = {
   connectTimeout: 10000,
   disconnectTimeout: 2000,
   retryStrategy: function (times) {
-    return Math.min(times * 50, 2000);
+    // Generate a random jitter between 0 – 200 ms:
+    const jitter = Math.floor(Math.random() * 200);
+    // Delay is an exponential back off, (times^2) * 50 ms, with a maximum value of 2000 ms:
+    const delay = Math.min(Math.pow(2, times) * 50, 2000);
+    return delay + jitter;
   },
   keepAlive: 0,
   noDelay: true,


### PR DESCRIPTION
The current default retry strategy increases delay linearly with no jitter. This can lead to a thundering herd problem if many clients lose their connection at once, which is common during events like a Redis upgrade.

A retry strategy that uses exponential backoff plus a random jitter helps mitigate this risk and [is recommended](https://aws.amazon.com/blogs/database/best-practices-redis-clients-and-amazon-elasticache-for-redis/) in many best practices documents for Redis clients, so I propose making this the default.

The default strategy I implemented will do the following:

* Delay will be equal to `(n^2) * 50` ms where `n` is the current retry count, with a maximum value of 2000 ms.
* Jitter is a random value between 0 and 200 ms.

The millisecond values I choose are somewhat arbitrary, and I'm happy to change them if we think they're not right.