### PR TITLE
fix: Improve cluster connection pool logic when disconnecting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,12 +35,12 @@ jobs:
           flag-name: node-${{matrix.node}}
           parallel: true
 
-  # test-cluster:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Build and test cluster
-  #       run: bash test/cluster/docker/main.sh
+  test-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and test cluster
+        run: bash test/cluster/docker/main.sh
 
   code-coverage:
     needs: test

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -7,7 +7,7 @@ const debug = Debug("cluster:connectionPool");
 
 type NODE_TYPE = "all" | "master" | "slave";
 
-type Node = {
+type NodeRecord = {
   redis: Redis;
   endListener: () => void;
   errorListener: (error: unknown) => void;
@@ -15,7 +15,7 @@ type Node = {
 
 export default class ConnectionPool extends EventEmitter {
   // master + slave = all
-  private nodes: { [key in NODE_TYPE]: { [key: string]: Node } } = {
+  private nodes: { [key in NODE_TYPE]: { [key: string]: NodeRecord } } = {
     all: {},
     master: {},
     slave: {},
@@ -45,7 +45,7 @@ export default class ConnectionPool extends EventEmitter {
   /**
    * Find or create a connection to the node
    */
-  findOrCreate(redisOptions: RedisOptions, readOnly = false): Node {
+  findOrCreate(redisOptions: RedisOptions, readOnly = false): NodeRecord {
     const key = getNodeKey(redisOptions);
     readOnly = Boolean(readOnly);
 
@@ -55,7 +55,7 @@ export default class ConnectionPool extends EventEmitter {
       this.specifiedOptions[key] = redisOptions;
     }
 
-    let node: Node;
+    let node: NodeRecord;
     if (this.nodes.all[key]) {
       node = this.nodes.all[key];
       if (node.redis.options.readOnly !== readOnly) {

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -97,7 +97,7 @@ export default class ConnectionPool extends EventEmitter {
 
       this.emit("+node", redis, key);
 
-      redis.on("error", function (error) {
+      redis.on("error", (error) => {
         this.emit("nodeError", error, key);
       });
     }

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -55,19 +55,19 @@ export default class ConnectionPool extends EventEmitter {
       this.specifiedOptions[key] = redisOptions;
     }
 
-    let node: NodeRecord;
+    let nodeRecord: NodeRecord;
     if (this.nodeRecords.all[key]) {
-      node = this.nodeRecords.all[key];
-      if (node.redis.options.readOnly !== readOnly) {
-        node.redis.options.readOnly = readOnly;
+      nodeRecord = this.nodeRecords.all[key];
+      if (nodeRecord.redis.options.readOnly !== readOnly) {
+        nodeRecord.redis.options.readOnly = readOnly;
         debug("Change role of %s to %s", key, readOnly ? "slave" : "master");
-        node.redis[readOnly ? "readonly" : "readwrite"]().catch(noop);
+        nodeRecord.redis[readOnly ? "readonly" : "readwrite"]().catch(noop);
         if (readOnly) {
           delete this.nodeRecords.master[key];
-          this.nodeRecords.slave[key] = node;
+          this.nodeRecords.slave[key] = nodeRecord;
         } else {
           delete this.nodeRecords.slave[key];
-          this.nodeRecords.master[key] = node;
+          this.nodeRecords.master[key] = nodeRecord;
         }
       }
     } else {
@@ -96,10 +96,10 @@ export default class ConnectionPool extends EventEmitter {
       const errorListener = (error: unknown) => {
         this.emit("nodeError", error, key);
       };
-      node = { redis, endListener, errorListener };
+      nodeRecord = { redis, endListener, errorListener };
 
-      this.nodeRecords.all[key] = node;
-      this.nodeRecords[readOnly ? "slave" : "master"][key] = node;
+      this.nodeRecords.all[key] = nodeRecord;
+      this.nodeRecords[readOnly ? "slave" : "master"][key] = nodeRecord;
 
       redis.once("end", endListener);
 
@@ -108,7 +108,7 @@ export default class ConnectionPool extends EventEmitter {
       redis.on("error", errorListener);
     }
 
-    return node;
+    return nodeRecord;
   }
 
   /**

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -150,8 +150,11 @@ export default class ConnectionPool extends EventEmitter {
    */
   private removeNode(key: string): void {
     const { nodes } = this;
-    if (nodes.all[key]) {
+    const node = nodes.all[key];
+    if (node) {
       debug("Remove %s from the pool", key);
+      node.redis.removeListener("end", node.endListener);
+      node.redis.removeListener("error", node.errorListener);
       delete nodes.all[key];
     }
     delete nodes.master[key];

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -92,10 +92,6 @@ export default class ConnectionPool extends EventEmitter {
       );
       const endListener = () => {
         this.removeNode(key);
-        this.emit("-node", redis, key);
-        if (!Object.keys(this.nodes.all).length) {
-          this.emit("drain");
-        }
       };
       const errorListener = (error: unknown) => {
         this.emit("nodeError", error, key);
@@ -156,8 +152,13 @@ export default class ConnectionPool extends EventEmitter {
       node.redis.removeListener("end", node.endListener);
       node.redis.removeListener("error", node.errorListener);
       delete nodes.all[key];
+      delete nodes.master[key];
+      delete nodes.slave[key];
+
+      this.emit("-node", node.redis, key);
+      if (!Object.keys(nodes.all).length) {
+        this.emit("drain");
+      }
     }
-    delete nodes.master[key];
-    delete nodes.slave[key];
   }
 }

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -128,16 +128,16 @@ export default class ConnectionPool extends EventEmitter {
       }
     });
 
+    Object.keys(newNodes).forEach((key) => {
+      const node = newNodes[key];
+      this.findOrCreate(node, node.readOnly);
+    });
     Object.keys(this.nodes.all).forEach((key) => {
       if (!newNodes[key]) {
         debug("Disconnect %s because the node does not hold any slot", key);
         this.nodes.all[key].redis.disconnect();
         this.removeNode(key);
       }
-    });
-    Object.keys(newNodes).forEach((key) => {
-      const node = newNodes[key];
-      this.findOrCreate(node, node.readOnly);
     });
   }
 

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -87,19 +87,21 @@ export default class ConnectionPool extends EventEmitter {
       this.nodes.all[key] = redis;
       this.nodes[readOnly ? "slave" : "master"][key] = redis;
 
-      redis.once("end", () => {
+      const endListener = () => {
         this.removeNode(key);
         this.emit("-node", redis, key);
         if (!Object.keys(this.nodes.all).length) {
           this.emit("drain");
         }
-      });
+      };
+      redis.once("end", endListener);
 
       this.emit("+node", redis, key);
 
-      redis.on("error", (error) => {
+      const errorListener = (error: unknown) => {
         this.emit("nodeError", error, key);
-      });
+      };
+      redis.on("error", errorListener);
     }
 
     return redis;

--- a/lib/cluster/ConnectionPool.ts
+++ b/lib/cluster/ConnectionPool.ts
@@ -39,14 +39,14 @@ export default class ConnectionPool extends EventEmitter {
   /**
    * Find or create a connection to the node
    */
-  findOrCreate(node: RedisOptions, readOnly = false): Redis {
-    const key = getNodeKey(node);
+  findOrCreate(redisOptions: RedisOptions, readOnly = false): Redis {
+    const key = getNodeKey(redisOptions);
     readOnly = Boolean(readOnly);
 
     if (this.specifiedOptions[key]) {
-      Object.assign(node, this.specifiedOptions[key]);
+      Object.assign(redisOptions, this.specifiedOptions[key]);
     } else {
-      this.specifiedOptions[key] = node;
+      this.specifiedOptions[key] = redisOptions;
     }
 
     let redis: Redis;
@@ -79,7 +79,7 @@ export default class ConnectionPool extends EventEmitter {
             enableOfflineQueue: true,
             readOnly: readOnly,
           },
-          node,
+          redisOptions,
           this.redisOptions,
           { lazyConnect: true }
         )

--- a/test/cluster/docker/main.sh
+++ b/test/cluster/docker/main.sh
@@ -1,4 +1,16 @@
-docker run -e "INITIAL_PORT=30000" -e "IP=0.0.0.0" -p 30000-30005:30000-30005 grokzen/redis-cluster:latest &
+#!/bin/bash
+
+set -euo pipefail
+
+docker run --rm --name redis-cluster-ioredis-test -e "INITIAL_PORT=30000" -e "IP=0.0.0.0" -p 30000-30005:30000-30005 grokzen/redis-cluster:latest &
+trap 'docker stop redis-cluster-ioredis-test' EXIT
+
 npm install
+
 sleep 15
+
+for port in {30000..30005}; do
+  docker exec redis-cluster-ioredis-test /bin/bash -c "redis-cli -p $port CONFIG SET protected-mode no"
+done
+
 npm run test:js:cluster || npm run test:js:cluster || npm run test:js:cluster


### PR DESCRIPTION
# Motivation and Background

This is an attempt to fix errors occurring when a `connect()` call is made shortly after a `disconnect()`, which is something that [the Bull library does when pausing a queue](https://github.com/OptimalBits/bull/blob/60fa88f08637f0325639988a3f054880a04ce402/lib/queue.js#L869-L871).

Here's a relatively minimal way to reproduce an error:

```js
import IORedis from "ioredis";

const cluster = new IORedis.Cluster([{ host: "localhost", port: 6380 }]);

await cluster.set("foo", "bar");

const endPromise = new Promise((resolve) => cluster.once("end", resolve));
await cluster.quit();
cluster.disconnect();
await endPromise;

cluster.connect();
console.log(await cluster.get("foo"));
cluster.disconnect();
```

Running that script in a loop using 

```sh
#!/bin/bash

set -euo pipefail

while true
do
    DEBUG=ioredis:cluster node cluster-error.mjs
done
```

against the `main` branch of `ioredis` quickly results in this output:

```
/Code/ioredis/built/cluster/index.js:124
                    reject(new redis_errors_1.RedisError("Connection is aborted"));
                           ^

RedisError: Connection is aborted
    at /Code/ioredis/built/cluster/index.js:124:28

Node.js v20.11.0
```

My debugging led me to believe that the existing node cleanup logic in the `ConnectionPool` class leads to race conditions: upon [`disconnect()`](https://github.com/redis/ioredis/blob/ec42c82ceab1957db00c5175dfe37348f1856a93/lib/cluster/index.ts#L283-L304), the [this.connectionPool.reset() call](https://github.com/redis/ioredis/blob/ec42c82ceab1957db00c5175dfe37348f1856a93/lib/cluster/index.ts#L302) will [remove nodes from the pool](https://github.com/redis/ioredis/blob/ec42c82ceab1957db00c5175dfe37348f1856a93/lib/cluster/ConnectionPool.ts#L129) without cleaning up [the event listener](https://github.com/redis/ioredis/blob/ec42c82ceab1957db00c5175dfe37348f1856a93/lib/cluster/ConnectionPool.ts#L90-L96) which may then subsequently issue more than one `drain` event. Depending on timing, one of the extra `drain` events may fire after `connect()` and [change the status to `close`](https://github.com/redis/ioredis/blob/ec42c82ceab1957db00c5175dfe37348f1856a93/lib/cluster/index.ts#L153), interfering with the connection event and leading to the error above.

# Changes

* Keep track of node listeners in the `ConnectionPool` class and remove them from the nodes whenever they are removed from the pool.
* Issue `-node` / `drain` regardless of whether nodes disconnected or were removed through a `reset()` call.
* Within `reset()`, add nodes before removing old ones to avoid unwanted `drain` events.
* Fix one of the listeners by using an arrow function to make `this` point to the connection pool instance.
* Try to fix the script for running cluster tests and attempt to enable them on CI. If this doesn't work out or isn't useful, I'm happy to revert the changes.
* Add a test around this issue. The error thrown in the test on `main` is seemingly different from the error shown above but it still seems related to the disconnection logic and still gets fixed by the changes in this PR.