### PR TITLE
fix `.time` return type to match actual values

### DIFF
--- a/bin/returnTypes.js
+++ b/bin/returnTypes.js
@@ -271,7 +271,7 @@ module.exports = {
   sunion: "string[]",
   sunionstore: "number",
   swapdb: "'OK'",
-  time: "number[]",
+  time: "[string, string]",
   touch: "number",
   ttl: "number",
   type: "string",


### PR DESCRIPTION
The `TIME` command returns as a two item list. https://redis.io/commands/time/

**Example**
```ts
await redis.time()
// ["1711650048", "618527"]
```