### PR TITLE
fix: Log Cluster.SLOTS errors on initial connection

### DIFF
--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -834,6 +834,7 @@ class Cluster extends Commander {
       timeout((err: Error, result) => {
         duplicatedConnection.disconnect();
         if (err) {
+          debug("error encountered running CLUSTER.SLOTS: %s", err);
           return callback(err);
         }
         if (


### PR DESCRIPTION
If Redis fails at that branch, Redis will swallow the error and give a generic `ClusterAllFailedError: Failed to refresh slots cache` error. Generally this error provides the actual reason for failure, e.g. invalid credentials.

This diagnostic can probably resolve most issues related to `ClusterAllFailedError: Failed to refresh slots cache`:

Fixed: https://github.com/redis/ioredis/issues/1800, https://github.com/redis/ioredis/issues/1454, https://github.com/redis/ioredis/issues/1415, https://github.com/redis/ioredis/issues/1103, https://github.com/redis/ioredis/issues/1003, https://github.com/redis/ioredis/issues/1062