### PR TITLE
Move to latest latest branch of coveralls action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run test:cov || npm run test:cov || npm run test:cov
       - name: Coveralls
         if: matrix.node == '18.x'
-        uses: coverallsapp/github-action@main
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: node-${{matrix.node}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         node: [12.x, 14.x, 16.x, 18.x]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           ref: ${{ inputs.branch || github.event.pull_request.head.ref || github.ref_name }} 
 
@@ -34,8 +34,8 @@ jobs:
       - run: npm run test:tsd
       - run: npm run test:cov || npm run test:cov || npm run test:cov
       - name: Coveralls
-        if: matrix.node == '18.x'
-        uses: coverallsapp/github-action@v2
+        if: matrix.node == '18.x' && false
+        uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: node-${{matrix.node}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         node: [12.x, 14.x, 16.x, 18.x]
     steps:
       - name: Git checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch || github.event.pull_request.head.ref || github.ref_name }} 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run test:cov || npm run test:cov || npm run test:cov
       - name: Coveralls
         if: matrix.node == '18.x'
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: node-${{matrix.node}}


### PR DESCRIPTION
Builds are failing right now because Coveralls is failing:

```
Error:  "2025-02-28T14:32:34.324Z"  'error from getOptions'
Error: Error: Command failed: git cat-file -p 175cc278a743175098a4727e92201922e3e1e270
fatal: Not a valid object name 175cc278a743175098a4727e92201922e3e1e270
```

Attempting to fix by using the `main` branch rather than the `master`