### PR TITLE
feat: added the option for disabling slots refresh, fixed concurrent calls to refreshSlotsCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1007,7 +1007,7 @@ cluster.get("foo", (err, res) => {
       state stabilized after a failover, so adding a delay before resending can prevent a ping pong effect.
     - `redisOptions`: Default options passed to the constructor of `Redis` when connecting to a node.
     - `slotsRefreshTimeout`: Milliseconds before a timeout occurs while refreshing slots from the cluster (default `1000`).
-    - `slotsRefreshInterval`: Milliseconds between every automatic slots refresh (default `5000`).
+    - `slotsRefreshInterval`: Milliseconds between every automatic slots refresh (default `5000`), setting it to a negative value will disable the slots refresh.
 
 ### Read-write splitting
 

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -531,9 +531,8 @@ class Cluster extends EventEmitter {
     }
     this.isRefreshing = true;
 
-    const _this = this;
     const wrapper = (error?: Error) => {
-      _this.isRefreshing = false;
+      this.isRefreshing = false;
       for (const callback of this._refreshSlotsCacheCallbacks) {
         callback(error);
       }
@@ -545,7 +544,7 @@ class Cluster extends EventEmitter {
 
     let lastNodeError = null;
 
-    function tryNode(index) {
+    const tryNode = (index: number) => {
       if (index === nodes.length) {
         const error = new ClusterAllFailedError(
           "Failed to refresh slots cache.",
@@ -556,8 +555,8 @@ class Cluster extends EventEmitter {
       const node = nodes[index];
       const key = `${node.options.host}:${node.options.port}`;
       debug("getting slot cache from %s", key);
-      _this.getInfoFromNode(node, function (err) {
-        switch (_this.status) {
+      this.getInfoFromNode(node, (err) => {
+        switch (this.status) {
           case "close":
           case "end":
             return wrapper(new Error("Cluster is disconnected."));
@@ -565,15 +564,15 @@ class Cluster extends EventEmitter {
             return wrapper(new Error("Cluster is disconnecting."));
         }
         if (err) {
-          _this.emit("node error", err, key);
+          this.emit("node error", err, key);
           lastNodeError = err;
           tryNode(index + 1);
         } else {
-          _this.emit("refresh");
+          this.emit("refresh");
           wrapper();
         }
       });
-    }
+    };
 
     tryNode(0);
   }

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -168,7 +168,7 @@ class Cluster extends EventEmitter {
   }
 
   resetNodesRefreshInterval() {
-    if (this.slotsTimer) {
+    if (this.slotsTimer || this.options.slotsRefreshInterval < 0) {
       return;
     }
     const nextRound = () => {

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -285,14 +285,13 @@ class Cluster extends EventEmitter {
           this.once("close", closeListener);
           this.once("close", this.handleCloseEvent.bind(this));
 
-          this.refreshSlotsCache(
-            function (err) {
-              if (err && err.message === "Failed to refresh slots cache.") {
-                Redis.prototype.silentEmit.call(this, "error", err);
-                this.connectionPool.reset([]);
-              }
-            }.bind(this)
-          );
+          this.refreshSlotsCache((err) => {
+            if (err && err.message === "Failed to refresh slots cache.") {
+              Redis.prototype.silentEmit.call(this, "error", err);
+              this.connectionPool.reset([]);
+            }
+          });
+
           this.subscriber.start();
 
           if (this.options.shardedSubscribers) {
@@ -533,7 +532,7 @@ class Cluster extends EventEmitter {
     this.isRefreshing = true;
 
     const _this = this;
-    const wrapper = function (error?: Error) {
+    const wrapper = (error?: Error) => {
       _this.isRefreshing = false;
       for (const callback of this._refreshSlotsCacheCallbacks) {
         callback(error);


### PR DESCRIPTION
Adding the option for disabling slots refresh by setting the slotsRefreshInterval option to a negative value, similar to https://github.com/redis/ioredis/commit/370fa625cd20bfe62f41c38088e596c7a6f0619c#diff-bf62b2774a434c4a07716686a3c1fbd23368a673a7633622bdf1a9a9cd087de5
Backported bugfix: when `refreshSlotsCache` is called concurrently, call the callback only when the refresh process is done #1881 