### PR TITLE
chore(release): stop overwriting npm `latest` dist-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GIT_AUTHOR_NAME: "ioredis robot"
           GIT_AUTHOR_EMAIL: "ioredis-robot@zihua.li"
-        run: npx semantic-release --branches v4
+        run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,11 @@
 {
-  "branches": ["v4"],
+  "branches": [
+    {
+      "name": "v4",
+      "tag": "v4",
+      "channel": "v4"
+    }
+  ],
   "verifyConditions": [
     "@semantic-release/npm",
     "@semantic-release/changelog",
@@ -23,10 +29,7 @@
       ]
     }
   ],
-  "publish": [
-    "@semantic-release/npm",
-    "@semantic-release/github"
-  ],
+  "publish": ["@semantic-release/npm", "@semantic-release/github"],
   "analyzeCommits": {
     "preset": "angular",
     "releaseRules": [


### PR DESCRIPTION
Assigns the v4 branch its own dist-tag (`v4`) and restricts it to the 4.x version range. This prevents v4 maintenance releases from overwriting the latest major version in the default npm channel.

#1974 