### PR TITLE
Force slots refresh on MOVED error when using ssubscribe

### DIFF
--- a/lib/DataHandler.ts
+++ b/lib/DataHandler.ts
@@ -80,6 +80,11 @@ export default class DataHandler {
       args: item.command.args,
     };
 
+    if (item.command.name == "ssubscribe" && err.message.includes("MOVED")) {
+      this.redis.emit("moved");
+      return;
+    }
+
     this.redis.handleReconnection(err, item);
   }
 

--- a/lib/cluster/ClusterSubscriber.ts
+++ b/lib/cluster/ClusterSubscriber.ts
@@ -160,6 +160,10 @@ export default class ClusterSubscriber {
     // Ignore the errors since they're handled in the connection pool.
     this.subscriber.on("error", noop);
 
+    this.subscriber.on("moved", () => {
+      this.emitter.emit("forceRefresh");
+    });
+
     // The node we lost connection to may not come back up in a
     // reasonable amount of time (e.g. a slave that's taken down
     // for maintainence), we could potentially miss many published

--- a/lib/cluster/ClusterSubscriberGroup.ts
+++ b/lib/cluster/ClusterSubscriberGroup.ts
@@ -31,7 +31,7 @@ export default class ClusterSubscriberGroup {
      *
      * @param cluster
      */
-    constructor(private cluster: Cluster) {
+    constructor(private cluster: Cluster, refreshSlotsCacheCallback: () => void) {
 
         cluster.on("+node", (redis) => {
             this._addSubscriber(redis);
@@ -43,6 +43,10 @@ export default class ClusterSubscriberGroup {
 
         cluster.on("refresh", () => {
             this._refreshSlots(cluster);
+        });
+
+        cluster.on("forceRefresh", () => {
+          refreshSlotsCacheCallback();
         });
     }
 

--- a/lib/cluster/index.ts
+++ b/lib/cluster/index.ts
@@ -126,7 +126,7 @@ class Cluster extends Commander {
     this.options = defaults({}, options, DEFAULT_CLUSTER_OPTIONS, this.options);
 
     if (this.options.shardedSubscribers == true)
-      this.shardedSubscribers = new ClusterSubscriberGroup(this);
+      this.shardedSubscribers = new ClusterSubscriberGroup(this, this.refreshSlotsCache.bind(this));
 
     if (
       this.options.redisOptions &&


### PR DESCRIPTION
When issuing a `ssubscribe` command, the Cluster client creates a "regular" Redis client to establish a connection to the correct shard. This doesn't work if there's a failover since the client doesn't know how to correctly handle a `MOVED` response. This PR handles such events by propagating the `ssubscribe MOVED` error from the `DataHandler`, through the `ClusterSubscriber` and the `ClusterSubscriberGroup` to the `RedisCluster` client and forces slots refresh.

Direct port from #1987