### PR TITLE
fix: emit connect once all handshake commands have been resolved

### DIFF
--- a/lib/DataHandler.ts
+++ b/lib/DataHandler.ts
@@ -14,6 +14,10 @@ export interface Condition {
   select: number;
   auth?: string | [string, string];
   subscriber: false | SubscriptionSet;
+  /**
+   * Whether the connection has issued a subscribe command during `connect` or `ready`.
+   */
+  hasIssuedSubscribe: boolean;
 }
 
 export type FlushQueueOptions = {

--- a/test/functional/pub_sub.ts
+++ b/test/functional/pub_sub.ts
@@ -213,4 +213,22 @@ describe("pub/sub", function () {
     expect(await redis.set("foo", "bar")).to.eql("OK");
     redis.disconnect();
   });
+
+  it("should subscribe on connect without errors", (done) => {
+    const redis = new Redis();
+    
+    redis.on("error", () => {
+      throw new Error("should not error");
+    });
+
+    redis.on("connect", async () => {
+      await redis.subscribe("foo");
+      redis.disconnect();
+
+      redis.on("end", () => {
+        // Make sure there's enough time for the error to be emitted
+        setTimeout(done, 500);
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR aims to resolve race conditions when a `(p)subscribe` is issued during `connect` status. Currently it's possible to either send a `client` or `info` handshake command after the `(p)subscribe` command has been issued and this might result either in the client rejecting the non-subscriber related command or the server rejecting it depending on the timing when the subscriber command was issued. This fix might lead to a situation in which some of the handshake commands are not sent to the server, however for example the ready check, which sends the `info` command does not make sense to happen on a subscriber connection, since the connection can only issue subscriber mode commands to the server.

Fixes #2037 