### PR TITLE
test(DataHandler): cover deeply nested reply causing decoder stack overflow

### DIFF
--- a/test/unit/DataHandler.ts
+++ b/test/unit/DataHandler.ts
@@ -266,6 +266,29 @@ describe("DataHandler", () => {
     expect(setup.redis.recoverFromFatalError.called).to.be.false;
     expect(setup.redis.commandQueue.length).to.equal(1);
   });
+
+  it("recovers instead of crashing on a reply that overflows the decoder's call stack | https://github.com/redis/ioredis/issues/2108", () => {
+    const setup = setupDataHandler();
+
+    // The decoder recurses once per level of RESP aggregate nesting, with no
+    // depth limit, so a sufficiently deeply nested reply (from a
+    // compromised/malicious server, or a corrupted stream) throws a
+    // synchronous RangeError instead of reporting a parser error.
+    let deeplyNested = ":1\r\n";
+    for (let i = 0; i < 50000; i++) {
+      deeplyNested = "*1\r\n" + deeplyNested;
+    }
+
+    expect(() => setup.write(deeplyNested)).to.not.throw();
+
+    expect(setup.redis.recoverFromFatalError.calledOnce).to.be.true;
+    const [commandError, err, options] =
+      setup.redis.recoverFromFatalError.firstCall.args;
+    expect(commandError).to.be.instanceOf(RangeError);
+    expect(err).to.equal(commandError);
+    expect(commandError.message).to.include("Maximum call stack size exceeded");
+    expect(options).to.deep.equal({ offlineQueue: false });
+  });
 });
 
 function setupDataHandler(parserOptions = { stringNumbers: false }) {


### PR DESCRIPTION
Fixes #2108.

`redis-parser` (and its replacement, the RESP3 Decoder from #2127) recurses
once per level of RESP aggregate nesting with no depth limit, so a
sufficiently deeply nested reply throws a RangeError instead of reporting a
parser error.

#2127 already wraps the decoder call in try/catch and routes failures
through the existing returnFatalError -> recoverFromFatalError path, so
this no longer needs a code change. There was no test pinning that behavior
down for this specific case, so this adds one.

Verified by temporarily removing the try/catch and confirming the new test
fails with the expected RangeError.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The change is narrowly scoped defensive error handling around inbound parsing; the diff here is test-only, with production behavior already aligned to the existing fatal-recovery path.
> 
> **Overview**
> This PR’s **visible diff** adds a **regression test** in `DataHandler` for issue #2108: feeding a reply nested ~50,000 `*1` arrays must **not** throw synchronously and must invoke **`recoverFromFatalError`** once with a **`RangeError`** (“Maximum call stack size exceeded”) and `{ offlineQueue: false }`.
> 
> The accompanying fix (described in the PR, not in the snippet above) wraps stream **`decoder.write`** in **`try/catch`** and forwards unexpected errors through the existing **`returnFatalError` → `recoverFromFatalError`** path so parser stack overflows recover instead of killing the Node process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831b5d85abfd68b7ead17c19e15c48a53b9995ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->