### PR TITLE
fix: decode integer replies up to MAX_SAFE_INTEGER exactly

### DIFF
--- a/lib/resp/decoder.ts
+++ b/lib/resp/decoder.ts
@@ -288,7 +288,9 @@ export class Decoder {
         this.#cursor = cursor + 2; // skip \r\n
         return number;
       }
-      number = number * 10 + byte - ASCII["0"];
+      // Subtract '0' before adding the digit: `number * 10 + byte` inflates
+      // the running total by 48, which crosses 2^53 one digit early and rounds.
+      number = number * 10 + (byte - ASCII["0"]);
     } while (++cursor < chunk.length);
 
     this.#cursor = cursor;

--- a/test/unit/DataHandler.ts
+++ b/test/unit/DataHandler.ts
@@ -48,6 +48,18 @@ describe("DataHandler", () => {
     expect(await command.promise).to.equal("123");
   });
 
+  it("resolves integer replies up to MAX_SAFE_INTEGER exactly", async () => {
+    const setup = setupDataHandler();
+    const command = new Command("incrby", ["counter", "1"], {
+      replyEncoding: "utf8",
+    });
+    setup.redis.commandQueue.push({ command, select: 0 });
+
+    setup.write(`:${Number.MAX_SAFE_INTEGER}\r\n`);
+
+    expect(await command.promise).to.equal(Number.MAX_SAFE_INTEGER);
+  });
+
   it("routes Redis errors as ReplyError-compatible errors", async () => {
     const setup = setupDataHandler();
     const command = new Command("get", ["key"], { replyEncoding: "utf8" });

--- a/test/unit/resp/decoder.ts
+++ b/test/unit/resp/decoder.ts
@@ -125,6 +125,23 @@ describe("RESP Decoder", () => {
       toWrite: Buffer.from(":1\r\n"),
       replies: ["1"],
     });
+
+    // `stringNumbers` is documented as being needed only *above*
+    // MAX_SAFE_INTEGER, so every integer up to it must decode exactly.
+    test("MAX_SAFE_INTEGER", {
+      toWrite: Buffer.from(`:${Number.MAX_SAFE_INTEGER}\r\n`),
+      replies: [Number.MAX_SAFE_INTEGER],
+    });
+
+    test("-MAX_SAFE_INTEGER", {
+      toWrite: Buffer.from(`:-${Number.MAX_SAFE_INTEGER}\r\n`),
+      replies: [-Number.MAX_SAFE_INTEGER],
+    });
+
+    test("MAX_SAFE_INTEGER - 46", {
+      toWrite: Buffer.from(":9007199254740945\r\n"),
+      replies: [9007199254740945],
+    });
   });
 
   describe("BigNumber", () => {


### PR DESCRIPTION
Integer replies just below `Number.MAX_SAFE_INTEGER` decode off by one:

```js
// server sends :9007199254740991\r\n  (Number.MAX_SAFE_INTEGER)
await redis.incrby("counter", 1);
// => 9007199254740992     expected 9007199254740991
```

Every integer from `MAX_SAFE_INTEGER - 46` up to `MAX_SAFE_INTEGER` is affected —
24 distinct values, all of which JavaScript can represent exactly.

### Cause

`#decodeUnsingedNumber` accumulates digits with:

```js
number = number * 10 + byte - ASCII["0"];
```

`+` and `-` are left-associative, so this is `(number * 10 + byte) - 48`: the raw
ASCII byte (48–57) is added to the running total *before* `'0'` is subtracted.
The intermediate is therefore 48 higher than the value being built. Once that
inflated intermediate passes 2^53 the addition is no longer exact, so it rounds —
and the later `- 48` cannot undo the rounding.

For `9007199254740991` the last step is `9007199254740990 + 49`, which is
`9007199254741039`, rounded to `9007199254741040`; minus 48 gives
`9007199254740992`.

Subtracting `'0'` from the digit first keeps every intermediate at or below the
final value, so nothing crosses 2^53 that the result doesn't.

### Why this range matters

`stringNumbers` is documented as being needed only for values *above* this
boundary:

> This is necessary if you want to handle big numbers (above `Number.MAX_SAFE_INTEGER` === 2^53).

— `RedisOptions.stringNumbers`, and the same advice was given in #2000. So the
safe-integer range is exactly where a plain `number` is supposed to be
trustworthy, and it currently isn't.

It is also a regression. `redis-parser@3.0.0`, which ioredis used through v5,
spells the same loop `(number * 10) + (c1 - 48)` and returns these values
exactly; I checked against it directly:

```
    9007199254740991  redis-parser=     9007199254740991   ioredis v6 decoder=     9007199254740992
```

The decoder landed recently in #2127, so this only affects v6.

### Verification

Found by differential-testing the decoder two ways: against an independent
non-streaming decoder written from the RESP3 spec, and against itself under every
possible chunk split. After the fix, ~14k (payload, type-mapping) pairs across
four seeds report zero divergences — including the `legacy`, `resp3` and
`stringNumbers` mappings from `DataHandler`. The chunk-splitting oracle found
nothing either before or after, so the streaming machinery itself looks solid.

Exhaustive sweep of the exactly-representable integers around the boundary,
before and after:

| range | representable values | decoded wrong before | after |
|---|---|---|---|
| 2^52 ± 100 | 201 | 0 | 0 |
| 2^53 ± 200 | 301 | 24 | 0 |

Tests added:

- `test/unit/resp/decoder.ts` — `MAX_SAFE_INTEGER`, `-MAX_SAFE_INTEGER` and
  `MAX_SAFE_INTEGER - 46`. The existing `test()` helper runs each of these as a
  single chunk, byte-by-byte, and split at every byte boundary.
- `test/unit/DataHandler.ts` — the same value observed where a caller sees it,
  as a resolved `incrby` reply.

All three fail on `main` and pass with the change; `test/unit` is green
(336 passing). I did not run the functional suite locally — it wants a live
Redis on 6379 and that port was taken on this machine — so CI is the check for
those.

### Scope

Only the integer/length accumulator. Two related things I deliberately left
alone:

- **Above `MAX_SAFE_INTEGER`**, the accumulation still rounds per digit and can
  differ from `Number(s)` by up to 4096 near `int64` max. Those values cannot be
  held exactly in a JS `number` at all, `stringNumbers` is the documented answer,
  and fixing it means either `Number(string)` or a BigInt fallback in a loop that
  also parses every bulk-string length. That felt like a separate discussion — happy
  to open one if you'd like it closed too.
- **The double path** (`#decodeDoubleInteger`, `#decodeDoubleExponent`) has the
  same left-to-right spelling, but #2150 replaces that whole family with
  `Number()`, so touching it here would only cause a conflict.

The fix keeps the same operation count — one multiply, two adds — and an A/B of
the two spellings over 2M iterations showed no difference outside run-to-run
noise (medians 2501 ms vs 2559 ms, with each variant's own spread spanning
1864–4190 ms on a loaded machine).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core RESP parsing used for integer replies and length fields; the change is small and well-tested but affects all numeric decode paths through `#decodeUnsingedNumber`.
> 
> **Overview**
> Fixes **off-by-one decoding** for RESP integer replies in the safe-integer range (including `Number.MAX_SAFE_INTEGER`), where values like `incrby` could resolve one too high.
> 
> In `#decodeUnsingedNumber`, digit accumulation now uses `number * 10 + (byte - ASCII["0"])` instead of left-associative `number * 10 + byte - ASCII["0"]`, so intermediates are not inflated by 48 before crossing 2^53 and rounding.
> 
> Adds regression tests in `test/unit/resp/decoder.ts` (`MAX_SAFE_INTEGER`, negatives, and `MAX_SAFE_INTEGER - 46` with chunk-split coverage) and `test/unit/DataHandler.ts` (end-to-end command reply at `MAX_SAFE_INTEGER`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf0b310c2f723dd2bb71632678e45868a3053ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->